### PR TITLE
Revert "Unblocks CI by ignoring non-impact Security warning"

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,6 @@
 [advisories]
 ignore = [
-    # Already patched, no impact on this project
-    # https://github.com/algesten/ureq/pull/748
-    "RUSTSEC-2024-0336",
+    # No advisories so far!
 ]
 
 [licenses]
@@ -14,7 +12,7 @@ allow = [
     "ISC",
     "BSD-3-Clause",
     "MPL-2.0",
-    "OpenSSL",
+    "OpenSSL"
 ]
 
 
@@ -22,4 +20,7 @@ allow = [
 [[licenses.clarify]]
 name = "ring"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+


### PR DESCRIPTION
Reverts dotanuki-labs/gradle-wrapper-validator#55

Follow-up of #56 